### PR TITLE
fix doc  useInjectHolder文档错误

### DIFF
--- a/docs/en/vue/advanced/holder.md
+++ b/docs/en/vue/advanced/holder.md
@@ -8,7 +8,7 @@ In addition to using defineOverlay and renderOverlay to create pop-up components
 import { useInjectHolder } from '@overlays/vue'
 import OverlayComponent from './overlay.vue'
 // Use useInjectHolder(Component) to create a component holder that supports the current context.
-const [overlayApi, holder] = useInjectHolder(ConfigProvider);
+const [overlayApi, holder] = useInjectHolder(OverlayComponent);
 
 function open() {
   // Open the pop-up component.

--- a/docs/en/vue/advanced/holder.md
+++ b/docs/en/vue/advanced/holder.md
@@ -8,7 +8,7 @@ In addition to using defineOverlay and renderOverlay to create pop-up components
 import { useInjectHolder } from '@overlays/vue'
 import OverlayComponent from './overlay.vue'
 // Use useInjectHolder(Component) to create a component holder that supports the current context.
-const [holder, overlayApi] = useInjectHolder(OverlayComponent)
+const [overlayApi, holder] = useInjectHolder(ConfigProvider);
 
 function open() {
   // Open the pop-up component.
@@ -18,7 +18,7 @@ function open() {
 </script>
 
 <template>
-  <div @click="overlayApi">
+  <div @click="open">
     open
   </div>
   <!-- Use <component :is="holder" /> to mount the component holder. -->

--- a/docs/zh/vue/advanced/holder.md
+++ b/docs/zh/vue/advanced/holder.md
@@ -8,7 +8,7 @@
 import { useInjectHolder } from '@overlays/vue'
 import OverlayComponent from './overlay.vue'
 // 通过 useInjectHolder(Component) 创建支持当前 context 的组件持有者
-const [overlayApi, holder] = useInjectHolder(ConfigProvider);
+const [overlayApi, holder] = useInjectHolder(OverlayComponent);
 
 function open() {
   // 打开弹出层

--- a/docs/zh/vue/advanced/holder.md
+++ b/docs/zh/vue/advanced/holder.md
@@ -8,7 +8,7 @@
 import { useInjectHolder } from '@overlays/vue'
 import OverlayComponent from './overlay.vue'
 // 通过 useInjectHolder(Component) 创建支持当前 context 的组件持有者
-const [holder, overlayApi] = useInjectHolder(OverlayComponent)
+const [overlayApi, holder] = useInjectHolder(ConfigProvider);
 
 function open() {
   // 打开弹出层
@@ -18,7 +18,7 @@ function open() {
 </script>
 
 <template>
-  <div @click="overlayApi">
+  <div @click="open">
     open
   </div>
   <!-- 使用 <component :is="holder" /> 挂载 -->


### PR DESCRIPTION
```vue
<!-- App.vue -->
<script setup>
import { useInjectHolder } from '@overlays/vue'
import OverlayComponent from './overlay.vue'
// 通过 useInjectHolder(Component) 创建支持当前 context 的组件持有者
// x 此处返回反了 const [holder, overlayApi] = useInjectHolder(OverlayComponent) 
const [overlayApi, holder] = useInjectHolder(OverlayComponent) // 实际返回

function open() {
  // 打开弹出层
  overlayApi()
    .then((result) => {})
}
</script>

<template>
  // x 此处函数绑定错误 <div @click="overlayApi">
  <div @click="open">// 正确函数
    open
  </div>
  <!-- 使用 <component :is="holder" /> 挂载 -->
  <component :is="holder" />
</template>
```