### PR TITLE
feat 支持包装弹出层组件

### DIFF
--- a/packages/@vue/src/define/constructor.ts
+++ b/packages/@vue/src/define/constructor.ts
@@ -3,13 +3,15 @@ import { pascalCase } from 'pascal-case'
 import type { AppContext, Component } from 'vue-demi'
 import { createApp, defineComponent, h, provide } from 'vue-demi'
 
-import { OverlayMetaKey } from '../internal'
+import { OverlayMetaKey, context, OptionsWapper } from '../internal'
 import { useVisibleScripts } from '../composable'
 import { inheritParent } from '../utils'
 
 export interface VMountOptions {
   /** current app context */
-  appContext?: AppContext
+  appContext?: AppContext,
+  /** wapper component */
+  wapper?: OptionsWapper
 }
 
 export const constructor = createConstructor<Component, VMountOptions>((Inst, props, options) => {
@@ -20,6 +22,9 @@ export const constructor = createConstructor<Component, VMountOptions>((Inst, pr
     container.remove()
   }
 
+  const wapper = options?.wapper ?? context.options?.wapper
+  const hInst = h(Inst, props)
+  const wapperInst = wapper ? h(wapper, null, hInst) : hInst
   const ChildApp = defineComponent({
     name: pascalCase(id),
     setup: () => {
@@ -29,7 +34,7 @@ export const constructor = createConstructor<Component, VMountOptions>((Inst, pr
       })
       provide(OverlayMetaKey, scripts)
     },
-    render: () => h(Inst, props),
+    render: () => wapperInst,
   })
 
   const app = createApp(ChildApp)

--- a/packages/@vue/src/index.ts
+++ b/packages/@vue/src/index.ts
@@ -1,8 +1,10 @@
 import type { App } from 'vue-demi'
 import { context } from './internal'
+import type { Options } from './internal'
 
-const install = (app: App) => {
+const install = (app: App, options: Options = {}) => {
   context.appContext = app._context
+  context.options = options
 }
 const unoverlay = { install }
 

--- a/packages/@vue/src/internal/index.ts
+++ b/packages/@vue/src/internal/index.ts
@@ -1,8 +1,17 @@
-import type { AppContext, InjectionKey } from 'vue-demi'
+import type { AppContext, Component, InjectionKey } from 'vue-demi'
 import type { UseOverlayReturn } from '../composable'
+
+export type OptionsWapper = Component | false
+
+export interface Options {
+  wapper?: OptionsWapper
+}
 
 export const context = {
   appContext: null as null | AppContext,
+  options: {
+    wapper: false
+  } as Options
 }
 
 export const OverlayMetaKey: InjectionKey<UseOverlayReturn> = Symbol('__imperative_overlay_key')


### PR DESCRIPTION
适配支持全局配置 Config Provider 
#39

使用方式
```js
// main.ts
import { createApp } from 'vue'
import App from './App.vue'
// 包装组件
import wapper from './wapper.vue'

import unoverlay from '@overlays/vue'

createApp(App).use(unoverlay,{
    // 使用wapper组件包装弹出层
    wapper: wapper
}).mount('#app')
```
```vue
<!-- wapper.vue -->
<script lang="ts">
import zhCn from 'element-plus/dist/locale/zh-cn.mjs'
</script>
<template>
    <el-config-provider :locale="zhCn">
        <slot></slot>
    </el-config-provider>
</template>
<style scoped>
</style>

```
